### PR TITLE
feat(reservas): add filtering by reservation state with pagination su…

### DIFF
--- a/src/main/java/com/project/deporturnos/controller/UsuarioController.java
+++ b/src/main/java/com/project/deporturnos/controller/UsuarioController.java
@@ -80,9 +80,9 @@ public class UsuarioController {
     @PreAuthorize("hasRole('ROLE_CLIENTE') or hasRole('ROLE_ADMIN')")
     @GetMapping("/{id}/reservas")
     public ResponseEntity<Page<ReservaResponseDTO>> getUserReservations(@PathVariable("id") Long id,
-            @RequestParam(value = "includeCompleted", required = false, defaultValue = "false") boolean includeCompleted,
+            @RequestParam(defaultValue = "FUTURAS") String estado,
             Pageable pageable) {
-        return ResponseEntity.ok(usuarioService.findReservationsByUserIdPaginated(id, includeCompleted, pageable));
+        return ResponseEntity.ok(usuarioService.findReservations(id, estado, pageable));
     }
 
     // Cambiar Contraseña

--- a/src/main/java/com/project/deporturnos/entity/domain/ReservaState.java
+++ b/src/main/java/com/project/deporturnos/entity/domain/ReservaState.java
@@ -4,6 +4,5 @@ public enum ReservaState {
     CONFIRMADA,
     EN_PROCESO,
     COMPLETADA,
-    MODIFICADA,
     CANCELADA
 }

--- a/src/main/java/com/project/deporturnos/repository/IReservaRepository.java
+++ b/src/main/java/com/project/deporturnos/repository/IReservaRepository.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Repository
 public interface IReservaRepository extends JpaRepository<Reserva, Long>, JpaSpecificationExecutor<Reserva> {
 
-    Page<Reserva> findByUsuarioIdAndEstadoNotAndDeletedFalse(Long id, ReservaState state, Pageable pageable);
+    Page<Reserva> findByUsuarioIdAndEstadoInAndDeletedFalse(Long id, List<ReservaState> estados, Pageable pageable);
 
     Page<Reserva> findByUsuarioIdAndDeletedFalse(Long id, Pageable pageable);
 

--- a/src/main/java/com/project/deporturnos/service/IUsuarioService.java
+++ b/src/main/java/com/project/deporturnos/service/IUsuarioService.java
@@ -22,7 +22,7 @@ public interface IUsuarioService {
 
     LockUnlockResponseDTO lockUnlock(Long id);
 
-    Page<ReservaResponseDTO> findReservationsByUserIdPaginated(Long id, boolean includeCompleted, Pageable pageable);
+    Page<ReservaResponseDTO> findReservations(Long id, String estado, Pageable pageable);
 
     ProfileResUpdateDTO updateProfile(Long id, @Valid ProfileReqUpdateDTO profileReqUpdateDTO);
 


### PR DESCRIPTION
…pport

Implemented new filtering logic for user reservations, allowing clients to query FUTURAS, COMPLETADAS, CANCELADAS or all states. Updated controller endpoint to receive 'estado' as query param, adjusted service logic to validate access and apply dynamic filters, and remove  MODIFICADA state from ReservaState.